### PR TITLE
Users name is missing in send magic code state #2278

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -30,7 +30,7 @@
 
 	<!-- MagicCodeVerificationPage (OTP)
 	OTP verification page for authenticating with a magic code -->
-	<Route path="/verify-magic-code/:id" component={VerifyMagicCode} />
+	<Route path="/verify-magic-code/:id/:name" component={VerifyMagicCode} />
 
 	<!-- EmailEntryPage
 	Page where the user enters their email, redirecting to login or registration based on context -->

--- a/src/pages/Auth/entry-point/EntryPoint.svelte
+++ b/src/pages/Auth/entry-point/EntryPoint.svelte
@@ -81,7 +81,7 @@
 		try {
 			const magicCodeResponse = await sendMagicCodeEmail({ email });
 			if (magicCodeResponse.isSuccessful) {
-				navigate(`/verify-magic-code/${email}`); // Updated this line
+				navigate(`/verify-magic-code/${email}/${magicCodeResponse.data}`); // Updated this line
 			} else {
 				if (magicCodeResponse?.message === 'Cooldown Active') {
 					navigate('/cool-down-active');

--- a/src/pages/Auth/login-page/LoginPage.svelte
+++ b/src/pages/Auth/login-page/LoginPage.svelte
@@ -242,9 +242,9 @@
 				</div>
 
 				{#if validationErrors?.password && isPasswordTouched}
-					<small class="form-text text-dangerColor">{validationErrors?.password}</small>
+					<small class="form-text text-dangerColor ">{validationErrors?.password}</small>
 				{:else if authenticationError}
-					<small class="form-text text-dangerColor"
+					<small class="form-text text-dangerColor email_and_password_error"
 						>The email and password combination you entered appears to be incorrect. Please try
 						again.</small
 					>
@@ -294,6 +294,9 @@
 {/if}
 
 <style>
+    .email_and_password_error{
+		font-size: 0.75rem;
+	}
 	.eye-icon {
 		right: 5px;
 		top: 50%;


### PR DESCRIPTION
Users name is missing in send magic code state
[#2278](https://github.com/sparrowapp-dev/sparrow-app/issues/2278)
Users name is missing in send magic code state #2278
https://github.com/sparrowapp-dev/sparrow-app/issues/2278
1.Enter previously used email.
2.Click on send magic code
Expected-

![image](https://github.com/user-attachments/assets/7b1af2cb-27ce-458b-8d45-4caf16d1f666)


Actual-
![image](https://github.com/user-attachments/assets/3198e66a-34c5-45e7-98a2-1de6c4ae83ea)


after solving the bug we get

![image](https://github.com/user-attachments/assets/9e95de7b-409c-47c9-8490-ba8bfb84ae7d)
