### PR TITLE
In Windows, Following validation message is not as per figma (should come in 2 line) #2386

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -30,7 +30,7 @@
 
 	<!-- MagicCodeVerificationPage (OTP)
 	OTP verification page for authenticating with a magic code -->
-	<Route path="/verify-magic-code/:id" component={VerifyMagicCode} />
+	<Route path="/verify-magic-code/:id/:name" component={VerifyMagicCode} />
 
 	<!-- EmailEntryPage
 	Page where the user enters their email, redirecting to login or registration based on context -->

--- a/src/pages/Auth/entry-point/EntryPoint.svelte
+++ b/src/pages/Auth/entry-point/EntryPoint.svelte
@@ -81,7 +81,7 @@
 		try {
 			const magicCodeResponse = await sendMagicCodeEmail({ email });
 			if (magicCodeResponse.isSuccessful) {
-				navigate(`/verify-magic-code/${email}`); // Updated this line
+				navigate(`/verify-magic-code/${email}/${magicCodeResponse.data}`); // Updated this line
 			} else {
 				if (magicCodeResponse?.message === 'Cooldown Active') {
 					navigate('/cool-down-active');

--- a/src/pages/Auth/login-page/LoginPage.svelte
+++ b/src/pages/Auth/login-page/LoginPage.svelte
@@ -244,9 +244,8 @@
 				{#if validationErrors?.password && isPasswordTouched}
 					<small class="form-text text-dangerColor ">{validationErrors?.password}</small>
 				{:else if authenticationError}
-					<small class="form-text text-dangerColor email_and_password_error"
-						>The email and password combination you entered appears to be incorrect. Please try
-						again.</small
+					<small class="form-text text-dangerColor"
+						>Invalid email or password. Please try again.</small
 					>
 				{/if}
 			</div>
@@ -294,9 +293,6 @@
 {/if}
 
 <style>
-    .email_and_password_error{
-		font-size: 0.75rem;
-	}
 	.eye-icon {
 		right: 5px;
 		top: 50%;

--- a/src/pages/Auth/login-page/LoginPage.svelte
+++ b/src/pages/Auth/login-page/LoginPage.svelte
@@ -242,9 +242,9 @@
 				</div>
 
 				{#if validationErrors?.password && isPasswordTouched}
-					<small class="form-text text-dangerColor">{validationErrors?.password}</small>
+					<small class="form-text text-dangerColor ">{validationErrors?.password}</small>
 				{:else if authenticationError}
-					<small class="form-text text-dangerColor"
+					<small class="form-text text-dangerColor email_and_password_error"
 						>The email and password combination you entered appears to be incorrect. Please try
 						again.</small
 					>
@@ -294,6 +294,9 @@
 {/if}
 
 <style>
+    .email_and_password_error{
+		font-size: 0.75rem;
+	}
 	.eye-icon {
 		right: 5px;
 		top: 50%;


### PR DESCRIPTION
In Windows, Following validation message is not as per figma (should come in 2 line)
[#2386](https://github.com/sparrowapp-dev/sparrow-app/issues/2386)

![image](https://github.com/user-attachments/assets/32fe2521-bd05-42dc-ac8e-4b2cde3b1c92)


after solving 
![image](https://github.com/user-attachments/assets/ae2154b5-c0ed-48f7-9e21-fc8b64b60832)
