### PR TITLE
In Windows, Following validation message is not as per figma (should come in 2 line) #2386

### DIFF
--- a/src/pages/Auth/login-page/LoginPage.svelte
+++ b/src/pages/Auth/login-page/LoginPage.svelte
@@ -245,8 +245,7 @@
 					<small class="form-text text-dangerColor">{validationErrors?.password}</small>
 				{:else if authenticationError}
 					<small class="form-text text-dangerColor"
-						>The email and password combination you entered appears to be incorrect. Please try
-						again.</small
+						>Invalid email or password. Please try again.</small
 					>
 				{/if}
 			</div>


### PR DESCRIPTION
In Windows, Following validation message is not as per figma (should come in 2 line) #2386


Expected
It should come in 2 lines
Actual-
The validation message is coming in 3 lines, which is not good as per the User experience

![image](https://github.com/user-attachments/assets/68d825c6-683b-49c8-9cf5-c3d61424a407)

after solving the bug  
![image](https://github.com/user-attachments/assets/1873449f-1778-4595-ba74-9ca98edb1a43)
