### PR TITLE
Users name is missing in send magic code state #2278

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -30,7 +30,7 @@
 
 	<!-- MagicCodeVerificationPage (OTP)
 	OTP verification page for authenticating with a magic code -->
-	<Route path="/verify-magic-code/:id" component={VerifyMagicCode} />
+	<Route path="/verify-magic-code/:id/:name" component={VerifyMagicCode} />
 
 	<!-- EmailEntryPage
 	Page where the user enters their email, redirecting to login or registration based on context -->

--- a/src/pages/Auth/entry-point/EntryPoint.svelte
+++ b/src/pages/Auth/entry-point/EntryPoint.svelte
@@ -81,7 +81,7 @@
 		try {
 			const magicCodeResponse = await sendMagicCodeEmail({ email });
 			if (magicCodeResponse.isSuccessful) {
-				navigate(`/verify-magic-code/${email}`); // Updated this line
+				navigate(`/verify-magic-code/${email}/${magicCodeResponse.data}`); // Updated this line
 			} else {
 				if (magicCodeResponse?.message === 'Cooldown Active') {
 					navigate('/cool-down-active');

--- a/src/pages/Auth/verify-magic-code/VerifyMagicCode.svelte
+++ b/src/pages/Auth/verify-magic-code/VerifyMagicCode.svelte
@@ -15,7 +15,15 @@
 
 	import CircleCheck from '$lib/assets/CircleCheck.svelte';
 	import { handleVerifyUserEmail, isSuccessfulResponseMagicCode } from './verify-magic-code';
+	import { string } from 'yup';
 	export let id: string;
+	export let name = string;
+	
+	 let firstName = name.split(' ')[0];
+	 
+	 console.log(firstName);
+	 
+
 
 	let seconds = 300; // Changed from 600 to 300 (5 minutes)
 	const verifyString = writable('');
@@ -265,7 +273,7 @@
 				class="container-header sparrow-fw-600 text-whiteColor text-center ms-2 me-2 mb-1"
 				style="font-size:24px; font-weight: 400;  line-height:28px; text-align:center;"
 			>
-				Welcome!
+				Welcome {firstName}
 			</p>
 			<p class="" style="color: lightGray; font-size:14px;">Just one more step</p>
 		</div>

--- a/src/pages/Auth/verify-magic-code/VerifyMagicCode.svelte
+++ b/src/pages/Auth/verify-magic-code/VerifyMagicCode.svelte
@@ -15,13 +15,11 @@
 
 	import CircleCheck from '$lib/assets/CircleCheck.svelte';
 	import { handleVerifyUserEmail, isSuccessfulResponseMagicCode } from './verify-magic-code';
-	import { string } from 'yup';
 	export let id: string;
-	export let name = string;
+	export let name: string ="";
 	
 	 let firstName = name.split(' ')[0];
-	 
-	 console.log(firstName);
+
 	 
 
 


### PR DESCRIPTION
Users name is missing in send magic code state
https://github.com/sparrowapp-dev/sparrow-app/issues/2278
Users name is missing in send magic code state #2278
https://github.com/sparrowapp-dev/sparrow-app/issues/2278
1.Enter previously used email.
2.Click on send magic code
Expected-
![image](https://github.com/user-attachments/assets/60b5c3ca-ce99-4e38-b77d-233bdbface83)

Actual-
![image](https://github.com/user-attachments/assets/2cc35eb2-2e19-442a-a53f-2761ec2e2189)

after solving the bug we get

![image](https://github.com/user-attachments/assets/075fb51c-1c2b-4b01-8ab3-8dd87348aea4)
