### PR TITLE
 One intermediate screen is present in dev after login, which is not present in figma (present in all the login and sign-up options) #2385

### DIFF
--- a/src/pages/Auth/oauth-redirect/OauthRedirect.svelte
+++ b/src/pages/Auth/oauth-redirect/OauthRedirect.svelte
@@ -28,10 +28,16 @@
 		} else { 
 			showRegisterComponent = false;
 			if (accessToken && refreshToken) {
+
 			if(userFromDesktop === "true"){
+				let data = JSON.parse(window.atob(accessToken?.split('.')[1]));
+				    let firstName  = data.name;
+					firstName =firstName.split(' ')[0] + "finfbgrubgfrbeuyreu";
+					firstName = firstName.length >11 ? firstName.substring(0, 5) + "..." : firstName;
+
+					redirectRules.title = `Welcome Back ${firstName}`;
 				setTimeout(() => {
-					let data = JSON.parse(window.atob(accessToken?.split('.')[1]));
-					redirectRules.title = `Welcome Back ${data.name}`;
+					
 					redirectRules.description = `Redirecting you to desktop app...`;
 					redirectRules.message = `the token if you are facing any issue in redirecting to the login page`;
 					

--- a/src/pages/Auth/oauth-redirect/OauthRedirect.svelte
+++ b/src/pages/Auth/oauth-redirect/OauthRedirect.svelte
@@ -32,7 +32,7 @@
 			if(userFromDesktop === "true"){
 				let data = JSON.parse(window.atob(accessToken?.split('.')[1]));
 				    let firstName  = data.name;
-					firstName =firstName.split(' ')[0] + "finfbgrubgfrbeuyreu";
+					firstName =firstName.split(' ')[0];
 					firstName = firstName.length >11 ? firstName.substring(0, 5) + "..." : firstName;
 
 					redirectRules.title = `Welcome Back ${firstName}`;


### PR DESCRIPTION
One intermediate screen is present in dev after login, which is not present in figma (present in all the login and sign-up options)
[#2385](https://github.com/sparrowapp-dev/sparrow-app/issues/2385)

1. Click on continue with google
2.Select account and click on continue
(check for all login methods)
(For sign up, welcome text should be present)
Expected-
Welcome back screen should present once user click on continue button
Implement wrap if name is to long in size
Implement first name only

![image](https://github.com/user-attachments/assets/ad0e281d-b873-466b-a64c-6288c957558c)

Actual-
One intermediate screen is present as shown below
First name and last name is present on screen

https://techdome-my.sharepoint.com/:v:/g/personal/shreyas_pharande_techdome_net_in/EfPTntgMo_FKnXo0un1qEWkBQQBcHol8ZZGsMKPF7KdTiQ?e=d3fxsZ

![image](https://github.com/user-attachments/assets/ba1ac8f1-2df6-4f66-a4bd-f7727739eea6)

after solving 
https://techdome-my.sharepoint.com/:v:/g/personal/mahendra_singh_techdome_net_in/EXi5Og6_J-dCqYSe-r9ViMMBdUbsiulVoRHTtSOUd7RJ2g?e=xhNMd6&nav=eyJyZWZlcnJhbEluZm8iOnsicmVmZXJyYWxBcHAiOiJTdHJlYW1XZWJBcHAiLCJyZWZlcnJhbFZpZXciOiJTaGFyZURpYWxvZy1MaW5rIiwicmVmZXJyYWxBcHBQbGF0Zm9ybSI6IldlYiIsInJlZmVycmFsTW9kZSI6InZpZXcifX0%3D

