### PR TITLE
One intermediate screen is present in dev after login, which is not present in figma (present in all the login and sign-up options) #2385

### DIFF
--- a/src/pages/Auth/oauth-redirect/OauthRedirect.svelte
+++ b/src/pages/Auth/oauth-redirect/OauthRedirect.svelte
@@ -29,9 +29,12 @@
 			showRegisterComponent = false;
 			if (accessToken && refreshToken) {
 			if(userFromDesktop === "true"){
+				let data = JSON.parse(window.atob(accessToken?.split('.')[1]));
+				 let firstName = data.name;
+				 firstName = firstName.split(' ')[0];
+				 firstName = firstName.length > 11 ? firstName.substring(0, 5) + "..." : firstName;
+					redirectRules.title = `Welcome Back ${firstName}`;
 				setTimeout(() => {
-					let data = JSON.parse(window.atob(accessToken?.split('.')[1]));
-					redirectRules.title = `Welcome Back ${data.name}`;
 					redirectRules.description = `Redirecting you to desktop app...`;
 					redirectRules.message = `the token if you are facing any issue in redirecting to the login page`;
 					


### PR DESCRIPTION
One intermediate screen is present in dev after login, which is not present in figma (present in all the login and sign-up options)
[#2385](https://github.com/sparrowapp-dev/sparrow-app/issues/2385)

1.Click on continue with google
2.Select account and click on continue
(check for all login methods)
(For sign up, welcome text should be present)
Expected-
Welcome back screen should present once user click on continue button
Implement wrap if name is to long in size
Implement first name only
![image](https://github.com/user-attachments/assets/dd833ce6-5a81-4baf-85e4-dc0cb9f6efcc)

Actual-
One intermediate screen is present as shown below
First name and last name is present on screen

https://techdome-my.sharepoint.com/:v:/g/personal/shreyas_pharande_techdome_net_in/EfPTntgMo_FKnXo0un1qEWkBQQBcHol8ZZGsMKPF7KdTiQ?e=d3fxsZ

after solving
![image](https://github.com/user-attachments/assets/d5360e9f-b369-4d31-a8f8-7cfd2955d8ed)
