### PR TITLE
 One intermediate screen is present in dev after login, which is not present in figma (present in all the login and sign-up options) #2385

### DIFF
--- a/src/pages/Auth/login-page/LoginPage.svelte
+++ b/src/pages/Auth/login-page/LoginPage.svelte
@@ -117,7 +117,10 @@
 							if (userFromDesktop === 'true') {
 								setTimeout(() => {
 									let data = JSON.parse(window.atob(accessToken?.split('.')[1]));
-									redirectRules.title = `Welcome Back ${data.name}`;
+									let firstName = data.name;
+									firstName = firstName.split(' ')[0];
+									firstName = firstName.length > 11 ? firstName.substring(0,5) + "...": firstName;
+									redirectRules.title = `Welcome Back ${firstName}`;
 									redirectRules.description = `Redirecting you to desktop app...`;
 									redirectRules.message = `If the application does not open automatically,
 							please click below.`;

--- a/src/pages/Auth/oauth-redirect/OauthRedirect.svelte
+++ b/src/pages/Auth/oauth-redirect/OauthRedirect.svelte
@@ -80,7 +80,10 @@
 			if(userFromDesktop === "true"){
 				setTimeout(() => {
 					let data = JSON.parse(window.atob(accessToken?.split('.')[1]));
-					redirectRules.title = `Welcome ${data.name}`;
+					let firstName = data.name;
+									firstName = firstName.split(' ')[0];
+									firstName = firstName.length > 11 ? firstName.substring(0,5) + "...": firstName;
+									redirectRules.title = `Welcome Back ${firstName}`;
 					redirectRules.description = `Redirecting you to desktop app...`;
 					redirectRules.message = `the token if you are facing any issue in redirecting to the login page`;
 					redirectRules.loadingMessage = '';


### PR DESCRIPTION
One intermediate screen is present in dev after login, which is not present in figma (present in all the login and sign-up options)
[#2385](https://github.com/sparrowapp-dev/sparrow-app/issues/2385)

updates 
like : 
only first name should come and if it length is greater then shorter the firstname

