### PR TITLE
fix: encode auth token in base64 for Sparrow deep link with backward compatibility [SPRW-3158]

### DIFF
--- a/src/pages/Auth/login-page/LoginPage.svelte
+++ b/src/pages/Auth/login-page/LoginPage.svelte
@@ -112,14 +112,32 @@
 							isLogin = true;
 							const accessToken = response?.accessToken?.token;
 							const refreshToken = response?.refreshToken?.token;
-							const sparrowRedirect = `sparrow://?selfhostBackendUrl=${constants.APP_EDITION === AppEdition.SELFHOSTED ? constants.API_URL : ""}&selfhostAdminUrl=${constants.APP_EDITION === AppEdition.SELFHOSTED ? constants.SPARROW_ADMIN_URL : ""}&selfhostWebUrl=${constants.APP_EDITION === AppEdition.SELFHOSTED ? constants.SPARROW_WEB_URL : ""}&accessToken=${accessToken}&refreshToken=${refreshToken}&response=${JSON.stringify(response)}&event=login&method=email`;
+							const payload = {
+								selfhostBackendUrl:
+									constants.APP_EDITION === AppEdition.SELFHOSTED ? constants.API_URL : '',
+								selfhostAdminUrl:
+									constants.APP_EDITION === AppEdition.SELFHOSTED
+										? constants.SPARROW_ADMIN_URL
+										: '',
+								selfhostWebUrl:
+									constants.APP_EDITION === AppEdition.SELFHOSTED ? constants.SPARROW_WEB_URL : '',
+								accessToken,
+								refreshToken,
+								response,
+								event: 'login',
+								method: 'email'
+							};
+
+							const encodedPayload = encodeURIComponent(btoa(JSON.stringify(payload)));
+
+							const sparrowRedirect = `sparrow://?data=${encodedPayload}`;
 							const sparrowWebRedirect =
 								constants.SPARROW_WEB_URL +
 								`?accessToken=${accessToken}&refreshToken=${refreshToken}&response=${JSON.stringify(response)}&event=login&method=email`;
 							let sparrowAdminRedirect =
 								constants.SPARROW_ADMIN_URL +
 								`?accessToken=${accessToken}&refreshToken=${refreshToken}&response=${JSON.stringify(response)}&event=login&method=email`;
-							if(flow === "standard") { 
+							if (flow === 'standard') {
 								sparrowAdminRedirect = sparrowAdminRedirect + '&flow=standard';
 							}
 							if (redirctSource === 'desktop') {

--- a/src/pages/Auth/self-host-login-page/SelfHostLoginPage.svelte
+++ b/src/pages/Auth/self-host-login-page/SelfHostLoginPage.svelte
@@ -112,9 +112,23 @@
 						isLogin = true;
 						const accessToken = response?.accessToken?.token;
 						const refreshToken = response?.refreshToken?.token;
-						const sparrowRedirect = `sparrow://?selfhostBackendUrl=${constants.APP_EDITION === AppEdition.SELFHOSTED ? constants.API_URL : ""}&selfhostAdminUrl=${constants.APP_EDITION === AppEdition.SELFHOSTED ? constants.SPARROW_ADMIN_URL : ""}&selfhostWebUrl=${constants.APP_EDITION === AppEdition.SELFHOSTED ? constants.SPARROW_WEB_URL : ""}&accessToken=${accessToken}&refreshToken=${refreshToken}&response=${JSON.stringify(response)}&event=login&method=email&isSelfHostLogin=true&backendUrl=${btoa(
-							sessionStorage.getItem(`selfhost-backendurl`) || ''
-						)}&adminUrl=${btoa(sessionStorage.getItem(`selfhost-adminurl`) || '')}`;
+						const payload = {
+							selfhostBackendUrl:
+								constants.APP_EDITION === AppEdition.SELFHOSTED ? constants.API_URL : '',
+							selfhostAdminUrl:
+								constants.APP_EDITION === AppEdition.SELFHOSTED ? constants.SPARROW_ADMIN_URL : '',
+							selfhostWebUrl:
+								constants.APP_EDITION === AppEdition.SELFHOSTED ? constants.SPARROW_WEB_URL : '',
+							accessToken,
+							refreshToken,
+							response,
+							event: 'login',
+							method: 'email'
+						};
+
+						const encodedPayload = encodeURIComponent(btoa(JSON.stringify(payload)));
+
+						const sparrowRedirect = `sparrow://?data=${encodedPayload}`;
 						const sparrowWebRedirect =
 							constants.SPARROW_WEB_URL +
 							`?accessToken=${accessToken}&refreshToken=${refreshToken}&response=${JSON.stringify(response)}&event=login&method=email`;


### PR DESCRIPTION
### Description

- Encoded login payload into base64 (data param) for secure and cleaner deep link handling
- Added decoding logic in desktop app with support for both new and legacy token formats
- Maintained existing navigation flow (sparrow://) without changes
- Reconstructed legacy token format internally to ensure compatibility with current login flow

### Add Issue Number
SPRW-3158
### Add Screenshots/GIFs

https://github.com/user-attachments/assets/bf52e195-392d-4f90-b5f3-f6af114acb2f


### Add Known Issue
If applicable, add any known issues.

### Contribution Checklist:
- [x] **The pull request only addresses one issue or adds one feature.**
- [x] **I have linked an issue to the pull request.**
- [x] **I have linked a PR type label to the pull request.**
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have added screenshots or GIFs to help explain the change if applicable.**
- [x] **I have read the [contribution guidelines](../../docs/CONTRIBUTING.md).**

Note: Keeping the PR small and focused helps make it easier to review and merge. If you have multiple changes you want to make, please consider submitting them as separate pull requests.